### PR TITLE
Fix recovery phase not firing because of incorrect state check

### DIFF
--- a/NEW-hilo-defi-blueprint.yaml
+++ b/NEW-hilo-defi-blueprint.yaml
@@ -1,4 +1,3 @@
-
 blueprint:
   name: Défis Hilo – Automatisation simplifiée (Ari Version)
   description: Gestion des défis Hilo avec filtrage AM/PM et remise à la normale en fin de défi
@@ -11,7 +10,6 @@ blueprint:
         entity:
           domain: sensor
 
-
     challenge_thermostats:
       name: Thermostats à gérer (au moins 1 requis)
       selector:
@@ -19,7 +17,7 @@ blueprint:
           domain: climate
           multiple: true
     #-  required: true
-      # Rend la sélection obligatoire (supprime les listes vides)
+    # Rend la sélection obligatoire (supprime les listes vides)
 
     water_heater_switch:
       name: Interrupteur Chauffe-eau (optionnel)
@@ -49,7 +47,7 @@ blueprint:
           unit_of_measurement: °C
 
     appreciation_temp:
-      name: Température pendant appréciation 
+      name: Température pendant appréciation
       description: 1 a 3AM et 12 a 2PM si appréciation est configuré à 2h dans l'intégration Hilo
       default: 21
       selector:
@@ -60,7 +58,7 @@ blueprint:
           unit_of_measurement: °C
 
     pre_heat_temp:
-      name: Température pré-chauffage 
+      name: Température pré-chauffage
       description: 2h avant Réduction/Défi
       default: 21
       selector:
@@ -138,26 +136,30 @@ variables:
   hour: "{{ now().hour }}"
 
   # Fenêtres AM/PM selon l'état courant
-  # AM: pré-chauffage 04–06, réduction 06–10, appréciation 01–03
+  # AM: appréciation 01–03, pré-chauffage 04–06, réduction 06–10, récupération 10–11
   is_am_window: >
-    {% if challenge_state == 'pre_heat' %}
+    {% if challenge_state == 'appreciation' %}
+      {{ (hour >= 1) and (hour < 4) }}
+    {% elif challenge_state == 'pre_heat' %}
       {{ (hour >= 4) and (hour < 6) }}
     {% elif challenge_state == 'reduction' %}
       {{ (hour >= 6) and (hour < 10) }}
-    {% elif challenge_state == 'appreciation' %}
-      {{ (hour >= 1) and (hour < 4) }}
+    {% elif challenge_state == 'recovery' %}
+      {{ (hour >= 10) and (hour < 11) }}
     {% else %}
       false
     {% endif %}
 
-  # PM: pré-chauffage 14–16, réduction 16–20, appréciation 12–14
+  # PM: appréciation 11–14, pré-chauffage 14–16, réduction 16–20, récupération 20–21
   is_pm_window: >
-    {% if challenge_state == 'pre_heat' %}
+    {% if challenge_state == 'appreciation' %}
+      {{ (hour >= 11) and (hour < 14) }}
+    {% elif challenge_state == 'pre_heat' %}
       {{ (hour >= 14) and (hour < 16) }}
     {% elif challenge_state == 'reduction' %}
       {{ (hour >= 16) and (hour < 20) }}
-    {% elif challenge_state == 'appreciation' %}
-      {{ (hour >= 11) and (hour < 14) }}
+    {% elif challenge_state == 'recovery' %}
+      {{ (hour >= 20) and (hour < 21) }}
     {% else %}
       false
     {% endif %}
@@ -165,7 +167,6 @@ variables:
   # Autorisation en fonction du choix AM/PM et de la fenêtre active
   window_ok: >
     {{ (challenge_am_flag and is_am_window) or (challenge_pm_flag and is_pm_window) }}
-
 
 action:
   - choose:
@@ -229,10 +230,10 @@ action:
             data:
               temperature: !input appreciation_temp
 
-      # ---------- Fin du défi : remise à la normale ----------
+      # ---------- Récupération : remise à la normale ----------
       - conditions:
           - condition: template
-            value_template: "{{ challenge_state not in ['pre_heat', 'reduction', 'appreciation'] and window_ok }}"
+            value_template: "{{ challenge_state == 'recovery' and window_ok }}"
         sequence:
           - service: climate.turn_on
             target:


### PR DESCRIPTION
The recovery phase was not being executed because window_ok was only being checked for pre_heat, reduction, and appreciation states. This commit corrects the condition to specifically check for the 'recovery' state, ensuring that the recovery actions are performed as intended.

File has been linted and formatted.
Window checks for AM and PM phases have been updated to include the recovery phase time slots. Window time slots have been sorted in logical order for better readability.